### PR TITLE
Broking link in Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -200,7 +200,7 @@ As solicitações de pull geralmente são analisadas em 10 dias úteis.
 ## <a name="more-resources"></a>Mais recursos
 
 * Para saber mais sobre o Markdown, acesse o site do criador do Git [Daring Fireball].
-* Para saber mais sobre como usar o Git e o GitHub, primeiro confira a [seção de ajuda do GitHub].
+* Para saber mais sobre como usar o Git e o GitHub, primeiro confira a seção de [ajuda do GitHub].
 
 [GitHub Home]: http://github.com
 [Ajuda do GitHub]: http://help.github.com/


### PR DESCRIPTION
In the section [Mais recursos](https://github.com/OfficeDev/office-js-docs-pr.pt-br/blob/live/Contributing.md#mais-recursos) in the file Contributing.md has a broken markdown to GitHub Help.

Before:
![image](https://user-images.githubusercontent.com/802968/47236894-d458db80-d3b3-11e8-8baf-89ce3f67ab7f.png)
After:
![image](https://user-images.githubusercontent.com/802968/47236926-f3576d80-d3b3-11e8-8065-39cf4c227093.png)